### PR TITLE
Allow views to be specified as ~/Views/MyView.cshtml in the Configuration

### DIFF
--- a/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
+++ b/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
@@ -17,7 +17,9 @@ namespace OpenRasta.Codecs.Razor
 
         public ViewDefinition GetViewDefinition(string path)
         {
-            var stream = _assembly.GetManifestResourceStream(string.Join(".", _baseNamespace,path));
+            path = path.Replace("~", "").Replace("/", ".");
+
+            var stream = _assembly.GetManifestResourceStream(_baseNamespace + path);
             if (stream == null)
             {
                 return null;

--- a/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
+++ b/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace OpenRasta.Codecs.Razor
 {
@@ -17,7 +18,7 @@ namespace OpenRasta.Codecs.Razor
 
         public ViewDefinition GetViewDefinition(string path)
         {
-            path = path.Replace("~", "").Replace("/", ".");
+            path = Regex.Replace(path, "^(~/)|/", ".");
 
             var stream = _assembly.GetManifestResourceStream(_baseNamespace + path);
             if (stream == null)


### PR DESCRIPTION
Allow views to be specified as ~/Views/MyView.cshtml in the Configuration so it can be used with both standalone hosting or Asp.Net hosting with views embedded in the assembly
