### PR TITLE
Issue resolving @resource type when the resource class is in a different assembly to the view

### DIFF
--- a/src/OpenRasta.Codecs.Razor.ConsoleTestApp/OpenRasta.Codecs.Razor.ConsoleTestApp.csproj
+++ b/src/OpenRasta.Codecs.Razor.ConsoleTestApp/OpenRasta.Codecs.Razor.ConsoleTestApp.csproj
@@ -68,7 +68,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <EmbeddedResource Include="Views\TestView.cshtml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/OpenRasta.Codecs.Razor/CompilationManager.cs
+++ b/src/OpenRasta.Codecs.Razor/CompilationManager.cs
@@ -51,7 +51,7 @@ namespace OpenRasta.Codecs.Razor
 
         private static CompilerParameters CreateCompilerParameters(IEnumerable<string> additionalAssemblies)
         {
-            var referencedAssemblies = new List<string>(additionalAssemblies)
+            var referencedAssemblies = new List<string>
                                            {
                                                "System.dll",
                                                "System.Core.dll",
@@ -65,6 +65,15 @@ namespace OpenRasta.Codecs.Razor
                                            };            
 
             var parameters = new CompilerParameters();
+
+            foreach (var current in additionalAssemblies)
+            {
+                if (!referencedAssemblies.Any(x => current.EndsWith("\\" + x) || current.Equals(x, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    referencedAssemblies.Add(current);
+                }
+            }
+
             parameters.ReferencedAssemblies.AddRange(referencedAssemblies.ToArray());
             parameters.GenerateExecutable = false;
             parameters.GenerateInMemory = true;

--- a/src/OpenRasta.Codecs.Razor/StandAloneBuildManager.cs
+++ b/src/OpenRasta.Codecs.Razor/StandAloneBuildManager.cs
@@ -44,7 +44,7 @@ namespace OpenRasta.Codecs.Razor
 
         private static IEnumerable<string> GetReferencedAssemblies(ViewDefinition viewDefinition)
         {
-            var referenced = viewDefinition.ViewAssembly.GetReferencedAssemblies().Select(x => x.CodeBase).ToList();
+            var referenced = viewDefinition.ViewAssembly.GetReferencedAssemblies().Select(x => Assembly.ReflectionOnlyLoad(x.FullName)).Select(x => x.Location).ToList();
             referenced.Add(viewDefinition.ViewAssembly.Location);
             return referenced;
         }


### PR DESCRIPTION
This commit is to fix an issue with type resolution when the resource class lives in a separate assembly to the view.

This line of code, from StandAloneBuildManager, is intended to pull in any referenced assemblies from the assembly containing the view:

 var referenced = viewDefinition.ViewAssembly.GetReferencedAssemblies().Select(x => x.CodeBase).ToList();

However, the CodeBase properties of the AssemblyName objects is null in every case. Executing a ReflectionOnlyLoad on each referenced assembly allows the correct value to be retrieved. However this requires an additional change in the CreateCompilerParameters method of CompilationManager to prevent assembly references being added twice.

Hope this is the right way to fix the problem...

Regards
Jon
