### PR TITLE
More flexible view specification, should cover all cases

### DIFF
--- a/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
+++ b/src/OpenRasta.Codecs.Razor/EmbeddedViewProvider.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace OpenRasta.Codecs.Razor
 {
@@ -16,16 +18,16 @@ namespace OpenRasta.Codecs.Razor
 
         public ViewDefinition GetViewDefinition(string path)
         {
-            path = path.Replace("~", "").Replace("/", ".");
-            var stream = _assembly.GetManifestResourceStream(_baseNamespace + path);
-          
+            path = Regex.Replace(path, "^(~/)|/", ".");
 
+            var streamName = path.StartsWith(".") ? _baseNamespace + path : _baseNamespace + "." + path;
+            var stream = _assembly.GetManifestResourceStream(streamName);
             if (stream == null)
             {
                 return null;
             }
             var reader = new StreamReader(stream);
-            return new ViewDefinition(path, reader, _assembly);
+            return new ViewDefinition(path, reader,_assembly);
         }
     }
 }


### PR DESCRIPTION
Allow view to specified as MyView.cshtml or ~/MyView.cshtml or ~/Views/MyView.cshtml or Views.MyView.cshtml
