### PR TITLE
WriteAttribute needs to take a params array and do some magic with it

### DIFF
--- a/src/OpenRasta.Codecs.Razor/AttributeValue.cs
+++ b/src/OpenRasta.Codecs.Razor/AttributeValue.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace OpenRasta.Codecs.Razor
+{
+    public class AttributeValue
+    {
+        AttributeValue(Tuple<string, int> prefix, Tuple<object, int> value, bool literal)
+        {
+            Prefix = prefix;
+            Value = value;
+            Literal = literal;
+        }
+
+        public Tuple<string, int> Prefix { get; private set; }
+        public Tuple<object, int> Value { get; private set; }
+        public bool Literal { get; private set; }
+
+        public static implicit operator AttributeValue(Tuple<Tuple<string, int>, Tuple<object, int>, bool> value)
+        {
+            return new AttributeValue(value.Item1, value.Item2, value.Item3);
+        }
+
+        public static implicit operator AttributeValue(Tuple<Tuple<string, int>, Tuple<string, int>, bool> value)
+        {
+            return new AttributeValue(value.Item1, Tuple.Create((object) value.Item2.Item1, value.Item2.Item2), value.Item3);
+        }
+    }
+}

--- a/src/OpenRasta.Codecs.Razor/OpenRasta.Codecs.Razor.csproj
+++ b/src/OpenRasta.Codecs.Razor/OpenRasta.Codecs.Razor.csproj
@@ -48,6 +48,7 @@
       <Link>CommonInfo.cs</Link>
     </Compile>
     <Compile Include="AspNetBuildManager.cs" />
+    <Compile Include="AttributeValue.cs" />
     <Compile Include="CompilationData.cs" />
     <Compile Include="CompilationManager.cs" />
     <Compile Include="EmbeddedViewProvider.cs" />

--- a/src/OpenRasta.Codecs.Razor/RazorViewBase.cs
+++ b/src/OpenRasta.Codecs.Razor/RazorViewBase.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Text;
 using System.Web;
 
 namespace OpenRasta.Codecs.Razor
@@ -33,17 +32,20 @@ namespace OpenRasta.Codecs.Razor
             Output.Write(value);
         }
 
-        public void WriteAttribute(string attr,
-                                           Tuple<string, int> token1,
-                                           Tuple<string, int> token2,
-                                           Tuple<Tuple<string, int>, Tuple<object, int>, bool> token3)
+        // This method is called by generated code and needs to stay in sync with the parser
+        public void WriteAttribute(string name,
+                                   Tuple<string, int> leader,
+                                   Tuple<string, int> trailer,
+                                   params AttributeValue[] parts)
         {
-            var stringBuilder = new StringBuilder();
-            if (token1 != null) stringBuilder.Append(token1.Item1);
-            if (token2 != null) stringBuilder.Append(token3.Item2.Item1);
-            if (token3 != null) stringBuilder.Append(token2.Item1);
-
-            Output.Write(stringBuilder.ToString());
+            WriteLiteral(leader);
+            foreach (var part in parts)
+            {
+                WriteLiteral(part.Prefix.Item1);
+                if (part.Literal) WriteLiteral(part.Value.Item1);
+                else Write(part.Value.Item1);
+            }
+            WriteLiteral(trailer);
         }
 
         // This method is called by generated code and needs to stay in sync with the parser


### PR DESCRIPTION
Pretty sure I have it now, this method should work properly. The issue is people can put anything in an attribute like

```
<a title="@prop abc def @prop2/@prop3">
```

So there needs a params array here. What I have written works for the use cases I could think of.

The code in ASP.NET MVC is much more complicated.
